### PR TITLE
Fix react-navigation package versions to work with expo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,6 +1110,16 @@
       "requires": {
         "deepmerge": "^3.2.0",
         "hoist-non-react-statics": "^3.3.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -1711,14 +1721,16 @@
       }
     },
     "@react-navigation/core": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.7.7.tgz",
-      "integrity": "sha512-0EYy7Hyip42Fua71w+Hti39u9tKzyNjdHZSWahWoZOZnEIgFwHmW3oT4A18Xv2l/rC2LOyfiddhp/Y1GIrV/3g==",
+      "version": "5.12.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.4.tgz",
+      "integrity": "sha512-vhaVIJGfSgln4dIoO4R2HeX9p3Vc7OJLa0/JpKHpXn/DZgNVn+RP7ktk1CRZ16ikUJ0k8CxzuvRxeRIg7EhA7w==",
       "requires": {
-        "hoist-non-react-statics": "^3.3.2",
-        "path-to-regexp": "^1.8.0",
+        "@react-navigation/routers": "^5.4.12",
+        "escape-string-regexp": "^4.0.0",
+        "nanoid": "^3.1.12",
         "query-string": "^6.13.1",
-        "react-is": "^16.13.0"
+        "react-is": "^16.13.0",
+        "use-subscription": "^1.4.0"
       }
     },
     "@react-navigation/drawer": {
@@ -1742,26 +1754,6 @@
       "requires": {
         "@react-navigation/core": "^5.12.4",
         "nanoid": "^3.1.12"
-      },
-      "dependencies": {
-        "@react-navigation/core": {
-          "version": "5.12.4",
-          "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.4.tgz",
-          "integrity": "sha512-vhaVIJGfSgln4dIoO4R2HeX9p3Vc7OJLa0/JpKHpXn/DZgNVn+RP7ktk1CRZ16ikUJ0k8CxzuvRxeRIg7EhA7w==",
-          "requires": {
-            "@react-navigation/routers": "^5.4.12",
-            "escape-string-regexp": "^4.0.0",
-            "nanoid": "^3.1.12",
-            "query-string": "^6.13.1",
-            "react-is": "^16.13.0",
-            "use-subscription": "^1.4.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        }
       }
     },
     "@react-navigation/routers": {
@@ -1832,9 +1824,9 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@unimodules/core": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-5.5.0.tgz",
-      "integrity": "sha512-i99Dw9Ie/8hSCn80hq6nKlklINdtOhhNqRf2BbF0xs03Ej/WYHsp6NaXReTifI5I7OP5djArEu2oYdZAFxFvbA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-5.5.1.tgz",
+      "integrity": "sha512-4OADQJqQ52TsCzfK+xUGWjt3zZADYxRvBZe8JXrnx2qGMXhFFUUn2JMEZT3nDt4QwtM+rIp9BsrQCMIPlXCOHg==",
       "requires": {
         "compare-versions": "^3.4.0"
       }
@@ -2363,9 +2355,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001141",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001141.tgz",
-      "integrity": "sha512-EHfInJHoQTmlMdVZrEc5gmwPc0zyN/hVufmGHPbVNQwlk7tJfCmQ2ysRZMY2MeleBivALUTyyxXnQjK18XrVpA=="
+      "version": "1.0.30001142",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
+      "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -2383,6 +2375,13 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        }
       }
     },
     "chardet": {
@@ -2752,44 +2751,24 @@
       }
     },
     "deep-equal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
-      "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.4.tgz",
+      "integrity": "sha512-BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==",
       "requires": {
-        "es-abstract": "^1.17.5",
+        "es-abstract": "^1.18.0-next.1",
         "es-get-iterator": "^1.1.0",
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.2",
-        "is-regex": "^1.0.5",
+        "is-regex": "^1.1.1",
         "isarray": "^2.0.5",
-        "object-is": "^1.1.2",
+        "object-is": "^1.1.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.2",
+        "side-channel": "^1.0.3",
         "which-boxed-primitive": "^1.0.1",
         "which-collection": "^1.0.1",
         "which-typed-array": "^1.1.2"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.7",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
       }
     },
     "deepmerge": {
@@ -3004,9 +2983,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -3141,13 +3120,6 @@
         "unimodules-sensors-interface": "~5.3.0",
         "unimodules-task-manager-interface": "~5.3.0",
         "uuid": "^3.4.0"
-      },
-      "dependencies": {
-        "react-native-safe-area-context": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.1.4.tgz",
-          "integrity": "sha512-bXx3hqz4LovFoMnJIRGIWL2oJ/PHadXviBKvgZV9yNErtURQLJSn0yfQytVtiqslhaBMZOJwH4R6HiClyofvBg=="
-        }
       }
     },
     "expo-asset": {
@@ -3217,9 +3189,9 @@
       }
     },
     "expo-location": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-9.0.0.tgz",
-      "integrity": "sha512-HsPyn/S73LS/LKpK0Cd/H9Dm9PohbnojYUM475s9DEeOBQitYbnSCKNdSz5vkG+Fqqh6mh4eHPy9dF/21I2rkg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-9.0.1.tgz",
+      "integrity": "sha512-yl4V2IelxrjG1h3nshkyILwghysNJvvEuR4Of0U7oYAsBrT0cq8NxFuaDemRvqt9Yb19wVFNMoVtYFNpthcqpQ=="
     },
     "expo-permissions": {
       "version": "9.3.0",
@@ -3480,6 +3452,13 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        }
       }
     },
     "file-uri-to-path": {
@@ -3754,12 +3733,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      }
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -4771,6 +4747,11 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -5052,6 +5033,11 @@
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
           }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "json5": {
           "version": "2.1.3",
@@ -6108,9 +6094,9 @@
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "query-string": {
-      "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.4.tgz",
-      "integrity": "sha512-E2NPIeJoBEJGQNy3ib1k/Z/OkDBUKIo8IV2ZVwbKfoa65IS9unqWWUlLcbfU70Da0qNoxUZZA8CfKUjKLE641Q==",
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
+      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -6543,12 +6529,12 @@
       }
     },
     "react-native-gesture-handler": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.8.0.tgz",
-      "integrity": "sha512-E2FZa0qZ5Bi0Z8Jg4n9DaFomHvedSjwbO2DPmUUHYRy1lH2yxXUpSrqJd6yymu+Efzmjg2+JZzsjFYA2Iq8VEQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.7.0.tgz",
+      "integrity": "sha512-1CrjJf8Z6Iz2XWzfZknYtsm2sud5Lu/pLhhokkgBIKttxqGDtetDEVFDJOTJWJyKCrUPk0X5tnWi/diSF4q++w==",
       "requires": {
         "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
+        "hoist-non-react-statics": "^2.3.1",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2"
       }
@@ -6577,9 +6563,9 @@
       }
     },
     "react-native-safe-area-context": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.1.8.tgz",
-      "integrity": "sha512-9gUlsDZ96QwT9AKzA6aVWM/NX5rlJgauZ9HgCDVzKbe29UQYT1740QJnnaI2GExmkFGp6o7ZLNhCXZW95eYVFA=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.1.4.tgz",
+      "integrity": "sha512-bXx3hqz4LovFoMnJIRGIWL2oJ/PHadXviBKvgZV9yNErtURQLJSn0yfQytVtiqslhaBMZOJwH4R6HiClyofvBg=="
     },
     "react-native-safe-area-view": {
       "version": "0.14.9",
@@ -6587,19 +6573,12 @@
       "integrity": "sha512-WII/ulhpVyL/qbYb7vydq7dJAfZRBcEhg4/UWt6F6nAKpLa3gAceMOxBxI914ppwSP/TdUsandFy6lkJQE0z4A==",
       "requires": {
         "hoist-non-react-statics": "^2.3.1"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
       }
     },
     "react-native-screens": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.11.0.tgz",
-      "integrity": "sha512-vJzJE3zI1XUtqthrX3Dh2TBQWB+xFyaGhF52KBq9FjJUN5ws4xpLZJxBWa1KbGV3DilmcSZ4jmZR5LGordwE7w=="
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.10.1.tgz",
+      "integrity": "sha512-Z2kKSk4AwWRQNCBmTjViuBQK0/Lx0jc25TZptn/2gKYUCOuVRvCekoA26u0Tsb3BIQ8tWDsZW14OwDlFUXW1aw=="
     },
     "react-native-vector-icons": {
       "version": "7.1.0",
@@ -6633,21 +6612,40 @@
       }
     },
     "react-navigation": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-4.4.1.tgz",
-      "integrity": "sha512-E0TJHLS8mcdliubPjbIfyplZG1oQhHYzH3cHKMSVXWE4dhSSf1x//r+92kW9LbS62v51Nj3Bxw2cJMHw0xP9Kw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-4.4.2.tgz",
+      "integrity": "sha512-QZaQL44ppzyeFA2o1f5HEKHbYJunRXEN7NFJVve51o5KANDadBvml84t7MKmarTmn01J69jZLIjDogkWNlaLQg==",
       "requires": {
-        "@react-navigation/core": "^3.7.7",
-        "@react-navigation/native": "^3.8.1"
+        "@react-navigation/core": "^3.7.8",
+        "@react-navigation/native": "^3.8.2"
       },
       "dependencies": {
+        "@react-navigation/core": {
+          "version": "3.7.8",
+          "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.7.8.tgz",
+          "integrity": "sha512-nqtOuTOTXgtFG57RbcotCgjuW/xznDJ9HnDAA37y+cuThG1Fpf4K3tGvVOyZiGd63xxvb+2NcLb89DPf6rzEkQ==",
+          "requires": {
+            "hoist-non-react-statics": "^3.3.2",
+            "path-to-regexp": "^1.8.0",
+            "query-string": "^6.13.1",
+            "react-is": "^16.13.0"
+          }
+        },
         "@react-navigation/native": {
-          "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.8.1.tgz",
-          "integrity": "sha512-EUOV7Ac09iMqphKidpLGnzn7pJr+XmDxJc4bGEKtMH/m/EpJYN93llzu9aPJxDJymMQsc/tyPIjJw2vKFcfNFQ==",
+          "version": "3.8.2",
+          "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.8.2.tgz",
+          "integrity": "sha512-8ImkbwKHf7MEM8XgorGpmfn+sgCKaJvzPowEqdWA2+AXnXlPymJWyehPSA255UbALXSHSiY5cEfhvPcEXwGllg==",
           "requires": {
             "hoist-non-react-statics": "^3.3.2",
             "react-native-safe-area-view": "^0.14.9"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^5.9.1",
     "@react-navigation/drawer": "^5.9.2",
     "@react-navigation/material-bottom-tabs": "^5.2.18",
@@ -19,11 +19,11 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-39.0.2.tar.gz",
+    "react-native-gesture-handler": "~1.7.0",
     "react-native-paper": "^4.2.0",
-    "react-native-gesture-handler": "^1.8.0",
-    "react-native-reanimated": "^1.13.1",
-    "react-native-safe-area-context": "^3.1.8",
-    "react-native-screens": "^2.11.0",
+    "react-native-reanimated": "~1.13.0",
+    "react-native-safe-area-context": "3.1.4",
+    "react-native-screens": "~2.10.1",
     "react-native-vector-icons": "^7.1.0",
     "react-native-web": "~0.13.12",
     "react-navigation": "^4.4.1"


### PR DESCRIPTION
The packages for `react-navigation` and its dependencies needed to be re-installed using `expo install` in order to properly work with Expo